### PR TITLE
Fix on Platform Support

### DIFF
--- a/windows/auxiliarys/CleanTracks.rb
+++ b/windows/auxiliarys/CleanTracks.rb
@@ -577,7 +577,7 @@ def ls_revert
        def run
        session = client
        # Check for proper target Platform
-       unsupported if client.platform !~ /win32|win64/i
+       unsupported if client.platform !~ /win32|win64|windows/i
 
          # Variable declarations (msf API calls)
          sysnfo = session.sys.config.sysinfo


### PR DESCRIPTION
Hi, I guess in some VMs the client.platform returns windows instead of win32 and win64. Hence provided the fix.